### PR TITLE
Appropriate exit code may not be returned in some cases

### DIFF
--- a/daemonocle/core.py
+++ b/daemonocle/core.py
@@ -270,8 +270,8 @@ class Daemon(object):
             # Wait for the first child, because it's going to wait and
             # check to make sure the second child is actually running
             # before exiting
-            os.waitpid(pid, 0)
-            sys.exit(0)
+            status = os.waitpid(pid, 0)
+            sys.exit(status[1] % 255)
 
         # Become a process group and session group leader
         os.setsid()


### PR DESCRIPTION
If the "grandchild" process fails outright, the "child" process fails with "Child exited immediately with exit code {code}", but the "parent" process exits with exit_code = 0, thus hiding the actual exit_code (makes it hard to restart or take other actions on failure using sysctl, etc.)