### PR TITLE
Fix python 3.8 compatibility in _is_socket()

### DIFF
--- a/daemonocle/core.py
+++ b/daemonocle/core.py
@@ -221,8 +221,11 @@ class Daemon(object):
             # If it has no file descriptor, it's not a socket
             return False
 
-        sock = socket.fromfd(fd, socket.AF_INET, socket.SOCK_RAW)
         try:
+            # This will raise a socket error on python 3.8 if it's not a
+            # socket, see https://bugs.python.org/issue39685
+            sock = socket.fromfd(fd, socket.AF_INET, socket.SOCK_RAW)
+
             # This will raise a socket.error if it's not a socket
             sock.getsockopt(socket.SOL_SOCKET, socket.SO_TYPE)
         except socket.error as ex:


### PR DESCRIPTION
Without this we're seeing

```
Traceback (most recent call last):
  File "/Users/fornwall/src/meeshkan/meeshkan/.venv/bin/meeshkan", line 11, in <module>
    load_entry_point('meeshkan', 'console_scripts', 'meeshkan')()
  File "/Users/fornwall/src/meeshkan/meeshkan/.venv/lib/python3.8/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/Users/fornwall/src/meeshkan/meeshkan/.venv/lib/python3.8/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/Users/fornwall/src/meeshkan/meeshkan/.venv/lib/python3.8/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/fornwall/src/meeshkan/meeshkan/.venv/lib/python3.8/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/fornwall/src/meeshkan/meeshkan/.venv/lib/python3.8/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/Users/fornwall/src/meeshkan/meeshkan/meeshkan/serve/commands.py", line 125, in mock
    daemon = daemonocle.Daemon(
  File "/Users/fornwall/src/meeshkan/meeshkan/.venv/lib/python3.8/site-packages/daemonocle/core.py", line 37, in __init__
    self.detach = detach & self._is_detach_necessary()
  File "/Users/fornwall/src/meeshkan/meeshkan/.venv/lib/python3.8/site-packages/daemonocle/core.py", line 260, in _is_detach_necessary
    if cls._is_socket(sys.stdin):
  File "/Users/fornwall/src/meeshkan/meeshkan/.venv/lib/python3.8/site-packages/daemonocle/core.py", line 224, in _is_socket
    sock = socket.fromfd(fd, socket.AF_INET, socket.SOCK_RAW)
  File "/Users/fornwall/.pyenv/versions/3.8.1/lib/python3.8/socket.py", line 544, in fromfd
    return socket(family, type, proto, nfd)
  File "/Users/fornwall/.pyenv/versions/3.8.1/lib/python3.8/socket.py", line 231, in __init__
    _socket.socket.__init__(self, family, type, proto, fileno)
OSError: [Errno 38] Socket operation on non-socket
```